### PR TITLE
Update edit.js to use className instead of class

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -34,8 +34,8 @@ import emptyHeartUrl from '../empty-heart.svg';
 export default function Edit() {
 	return (
 		<div {...useBlockProps()}>
-			<div class="like-button-parent">
-				<div class="like-button-child">
+			<div className="like-button-parent">
+				<div className="like-button-child">
 					<img
 						draggable="false"
 						role="img"


### PR DESCRIPTION
Whilte testing https://github.com/WordPress/gutenberg/pull/51449 I noticed this warning