### PR TITLE
Add Playground blueprint and zip file.

### DIFF
--- a/_playground/blueprint.json
+++ b/_playground/blueprint.json
@@ -10,16 +10,6 @@
 		{
 			"step": "installPlugin",
 			"pluginZipFile": {
-				"resource": "wordpress.org/plugins",
-				"slug": "gutenberg"
-			},
-			"options": {
-				"activate": true
-			}
-		},
-		{
-			"step": "installPlugin",
-			"pluginZipFile": {
 				"resource": "url",
 				"url": "https://raw.githubusercontent.com/ockham/like-button/trunk/_playground/like-button.zip"
 			},

--- a/_playground/blueprint.json
+++ b/_playground/blueprint.json
@@ -4,7 +4,7 @@
 		"networking": true
 	},
 	"steps": [
-        {
+		{
 			"step": "login"
 		},
 		{

--- a/_playground/blueprint.json
+++ b/_playground/blueprint.json
@@ -1,0 +1,31 @@
+{
+	"landingPage": "/wp-admin/site-editor.php",
+	"features": {
+		"networking": true
+	},
+	"steps": [
+        {
+			"step": "login"
+		},
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "wordpress.org/plugins",
+				"slug": "gutenberg"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "url",
+				"url": "https://raw.githubusercontent.com/ockham/like-button/trunk/_playground/like-button.zip"
+			},
+			"options": {
+				"activate": true
+			}
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
 		"packages-update": "wp-scripts packages-update",
-		"plugin-zip": "wp-scripts plugin-zip",
-		"start": "wp-scripts start --webpack-copy-php"
+		"start": "wp-scripts start --webpack-copy-php",
+		"plugin-zip": "wp-scripts plugin-zip && copyfiles --verbose like-button.zip _playground/ && rm like-button.zip"
 	},
 	"devDependencies": {
 		"@wordpress/scripts": "^26.7.0"


### PR DESCRIPTION
The PR adds the zip file for the block to githubusercontent, which can then be used in a Playground blueprint. The direct zip file cannot be used due to CORS errors.